### PR TITLE
Preloading

### DIFF
--- a/examples/read-all-inlines.py
+++ b/examples/read-all-inlines.py
@@ -1,0 +1,22 @@
+from seismic_zfp.read import SzReader
+import time
+import os
+import sys
+
+base_path = sys.argv[1]
+
+CLIP = 0.2
+SCALE = 1.0/(2.0*CLIP)
+
+with SzReader(os.path.join(base_path, 'psdn11_TbsdmF_full_w_AGC_Nov11.sz'), preload=True) as reader:
+    t0 = time.time()
+    for i in range(reader.n_ilines):
+        slice_sz = reader.read_inline(i)
+    print("SzReader (with preloading) took", time.time() - t0)
+
+with SzReader(os.path.join(base_path, 'psdn11_TbsdmF_full_w_AGC_Nov11.sz'), preload=False) as reader:
+    t0 = time.time()
+    for i in range(reader.n_ilines):
+        slice_sz = reader.read_inline(i)
+    print("SzReader (without preloading) took", time.time() - t0)
+

--- a/seismic_zfp/loader.py
+++ b/seismic_zfp/loader.py
@@ -4,9 +4,11 @@ from pyzfp import decompress
 
 
 class SzLoader:
-    def __init__(self, file, data_start_bytes, shape_pad, blockshape, chunk_bytes, block_bytes, unit_bytes, rate):
+    def __init__(self, file, data_start_bytes, compressed_data_diskblocks, shape_pad, blockshape,
+                 chunk_bytes, block_bytes, unit_bytes, rate, preload=False):
         self.file = file
         self.data_start_bytes = data_start_bytes
+        self.compressed_data_diskblocks = compressed_data_diskblocks
         self.shape_pad = shape_pad
         self.blockshape = blockshape
         self.chunk_bytes = chunk_bytes
@@ -14,12 +16,28 @@ class SzLoader:
         self.unit_bytes = unit_bytes
         self.rate = rate
 
+        self.compressed_volume = None
+        if preload:
+            self.load_compressed_volume()
+
+    def load_compressed_volume(self):
+        if self.compressed_volume is None:
+            self.file.seek(self.data_start_bytes)
+            self.compressed_volume = self.file.read(self.compressed_data_diskblocks * self.block_bytes)
+        else:
+            pass
+
+    def get_compressed_bytes(self, offset, length_bytes):
+        if self.compressed_volume is not None:
+            return self.compressed_volume[offset:offset+length_bytes]
+        else:
+            self.file.seek(self.data_start_bytes + offset, 0)
+            return self.file.read(length_bytes)
+
     @lru_cache(maxsize=1)
     def read_and_decompress_il_set(self, i):
         il_block_offset = ((self.chunk_bytes * self.shape_pad[1]) // 4) * (i // 4)
-
-        self.file.seek(self.data_start_bytes + il_block_offset, 0)
-        buffer = self.file.read(self.chunk_bytes * self.shape_pad[1])
+        buffer = self.get_compressed_bytes(il_block_offset, self.chunk_bytes * self.shape_pad[1])
 
         # Specify dtype otherwise pyzfp gets upset.
         return decompress(buffer, (self.blockshape[0], self.shape_pad[1], self.shape_pad[2]),
@@ -34,9 +52,8 @@ class SzLoader:
         buffer = bytearray(self.chunk_bytes * self.shape_pad[0] // 4)
 
         for chunk_num in range(self.shape_pad[0] // 4):
-            self.file.seek(self.data_start_bytes + xl_first_chunk_offset
-                           + chunk_num * xl_chunk_increment, 0)
-            buffer[chunk_num * self.chunk_bytes:(chunk_num + 1) * self.chunk_bytes] = self.file.read(self.chunk_bytes)
+            part = self.get_compressed_bytes(xl_first_chunk_offset + chunk_num * xl_chunk_increment, self.chunk_bytes)
+            buffer[chunk_num * self.chunk_bytes:(chunk_num + 1) * self.chunk_bytes] = part
 
         # Specify dtype otherwise pyzfp gets upset.
         return decompress(buffer, (self.shape_pad[0], self.blockshape[1], self.shape_pad[2]),
@@ -48,10 +65,10 @@ class SzLoader:
         # Allocate memory for compressed data
         buffer = bytearray(self.unit_bytes * (blocks_per_dim[0]) * (blocks_per_dim[1]))
         for block_num in range((blocks_per_dim[0]) * (blocks_per_dim[1])):
-            self.file.seek(self.data_start_bytes + zslice_first_block_offset * self.block_bytes
-                           + zslice_unit_in_block * self.unit_bytes
-                           + block_num * self.chunk_bytes, 0)
-            buffer[block_num * self.unit_bytes:(block_num + 1) * self.unit_bytes] = self.file.read(self.unit_bytes)
+            part = self.get_compressed_bytes(zslice_first_block_offset * self.block_bytes
+                                             + zslice_unit_in_block * self.unit_bytes
+                                             + block_num * self.chunk_bytes, self.unit_bytes)
+            buffer[block_num * self.unit_bytes:(block_num + 1) * self.unit_bytes] = part
         # Specify dtype otherwise pyzfp gets upset.
         decompressed = decompress(buffer, (self.shape_pad[0], self.shape_pad[1], 4),
                                   np.dtype('float32'), rate=self.rate)
@@ -64,12 +81,12 @@ class SzLoader:
         for block_i in range(blocks_per_dim[0]):
             for block_x in range(blocks_per_dim[1]):
                 block_num = block_i * (blocks_per_dim[1]) + block_x
-                self.file.seek(self.data_start_bytes + zslice_first_block_offset * self.block_bytes + block_num * (
-                            self.block_bytes * (blocks_per_dim[2])), 0)
-                temp_buf = self.file.read(self.block_bytes)
+                temp_buf = self.get_compressed_bytes(zslice_first_block_offset * self.block_bytes
+                                                     + block_num * (self.block_bytes * (blocks_per_dim[2])),
+                                                     self.block_bytes)
                 for sub_block_num in range(self.blockshape[0] // 4):
                     buf_start = block_i * self.block_bytes * (
-                    blocks_per_dim[1]) + block_x * sub_block_size_bytes + sub_block_num * (
+                        blocks_per_dim[1]) + block_x * sub_block_size_bytes + sub_block_num * (
                                             (self.shape_pad[1] * 4 * 4 * self.rate) // 8)
                     buffer[buf_start:buf_start + sub_block_size_bytes] = \
                         temp_buf[sub_block_num * sub_block_size_bytes:(sub_block_num + 1) * sub_block_size_bytes]
@@ -91,9 +108,8 @@ class SzLoader:
         buffer = bytearray(self.chunk_bytes * self.shape_pad[0] // 4)
 
         for chunk_num in range(self.shape_pad[0] // 4):
-            self.file.seek(self.data_start_bytes + xl_first_chunk_offset
-                           + chunk_num * xl_chunk_increment, 0)
-            buffer[chunk_num * self.chunk_bytes:(chunk_num + 1) * self.chunk_bytes] = self.file.read(self.chunk_bytes)
+            part = self.get_compressed_bytes(xl_first_chunk_offset + chunk_num * xl_chunk_increment, self.chunk_bytes)
+            buffer[chunk_num * self.chunk_bytes:(chunk_num + 1) * self.chunk_bytes] = part
 
         # Specify dtype otherwise pyzfp gets upset.
         return decompress(buffer, (self.shape_pad[0], self.blockshape[1], self.shape_pad[2]),
@@ -112,9 +128,8 @@ class SzLoader:
         buffer = bytearray(self.chunk_bytes * self.shape_pad[0] // 4)
 
         for chunk_num in range(self.shape_pad[0] // 4):
-            self.file.seek(self.data_start_bytes + xl_first_chunk_offset
-                           + chunk_num * xl_chunk_increment, 0)
-            buffer[chunk_num * self.chunk_bytes:(chunk_num + 1) * self.chunk_bytes] = self.file.read(self.chunk_bytes)
+            part = self.get_compressed_bytes(xl_first_chunk_offset + chunk_num * xl_chunk_increment, self.chunk_bytes)
+            buffer[chunk_num * self.chunk_bytes:(chunk_num + 1) * self.chunk_bytes] = part
 
         # Specify dtype otherwise pyzfp gets upset.
         return decompress(buffer, (self.shape_pad[0], self.blockshape[1], self.shape_pad[2]),
@@ -131,13 +146,14 @@ class SzLoader:
         for i in range(il_units):
             for x in range(xl_units):
                 # No need to loop over z... it's contiguous, so do it in one file read
-                self.file.seek(self.data_start_bytes + self.unit_bytes * (
-                        (i + (min_il // 4)) * (self.shape_pad[1] // 4) * (self.shape_pad[2] // 4) +
-                        (x + (min_xl // 4)) * (self.shape_pad[2] // 4) +
-                        (min_z // 4)), 0)
+                bytes_start = self.unit_bytes * (
+                                (i + (min_il // 4)) * (self.shape_pad[1] // 4) * (self.shape_pad[2] // 4) +
+                                (x + (min_xl // 4)) * (self.shape_pad[2] // 4) +
+                                (min_z // 4))
                 buf_start = (i * xl_units * z_units + x * z_units) * self.unit_bytes
                 buf_end = buf_start + read_length
-                buffer[buf_start:buf_end] = self.file.read(read_length)
+                part = self.get_compressed_bytes(bytes_start, read_length)
+                buffer[buf_start:buf_end] = part
         # Specify dtype otherwise pyzfp gets upset.
         decompressed = decompress(buffer, (il_units * 4, xl_units * 4, z_units * 4),
                                   np.dtype('float32'), rate=self.rate)
@@ -154,12 +170,12 @@ class SzLoader:
         for i in range(il_blocks):
             for x in range(xl_blocks):
                 for z in range(z_blocks):
-                    self.file.seek(self.data_start_bytes + self.block_bytes * (
+                    bytes_start = self.block_bytes * (
                             (i + (min_il // self.blockshape[0])) * (self.shape_pad[1] // self.blockshape[1]) * (
                                 self.shape_pad[2] // self.blockshape[2]) +
                             (x + (min_xl // self.blockshape[1])) * (self.shape_pad[2] // self.blockshape[2]) +
-                            (z + (min_z // self.blockshape[2]))), 0)
-                    buffer = self.file.read(self.block_bytes)
+                            (z + (min_z // self.blockshape[2])))
+                    buffer = self.get_compressed_bytes(bytes_start, self.block_bytes)
                     decompressed_part = decompress(buffer,
                                                    (self.blockshape[0], self.blockshape[1], self.blockshape[2]),
                                                    np.dtype('float32'), rate=self.rate)

--- a/seismic_zfp/loader.py
+++ b/seismic_zfp/loader.py
@@ -1,0 +1,169 @@
+from functools import lru_cache
+import numpy as np
+from pyzfp import decompress
+
+
+class SzLoader:
+    def __init__(self, file, data_start_bytes, shape_pad, blockshape, chunk_bytes, block_bytes, unit_bytes, rate):
+        self.file = file
+        self.data_start_bytes = data_start_bytes
+        self.shape_pad = shape_pad
+        self.blockshape = blockshape
+        self.chunk_bytes = chunk_bytes
+        self.block_bytes = block_bytes
+        self.unit_bytes = unit_bytes
+        self.rate = rate
+
+    @lru_cache(maxsize=1)
+    def read_and_decompress_il_set(self, i):
+        il_block_offset = ((self.chunk_bytes * self.shape_pad[1]) // 4) * (i // 4)
+
+        self.file.seek(self.data_start_bytes + il_block_offset, 0)
+        buffer = self.file.read(self.chunk_bytes * self.shape_pad[1])
+
+        # Specify dtype otherwise pyzfp gets upset.
+        return decompress(buffer, (self.blockshape[0], self.shape_pad[1], self.shape_pad[2]),
+                                  np.dtype('float32'), rate=self.rate)
+
+    @lru_cache(maxsize=1)
+    def read_and_decompress_xl_set(self, x):
+        xl_first_chunk_offset = x // 4 * self.chunk_bytes
+        xl_chunk_increment = self.chunk_bytes * self.shape_pad[1] // 4
+
+        # Allocate memory for compressed data
+        buffer = bytearray(self.chunk_bytes * self.shape_pad[0] // 4)
+
+        for chunk_num in range(self.shape_pad[0] // 4):
+            self.file.seek(self.data_start_bytes + xl_first_chunk_offset
+                           + chunk_num * xl_chunk_increment, 0)
+            buffer[chunk_num * self.chunk_bytes:(chunk_num + 1) * self.chunk_bytes] = self.file.read(self.chunk_bytes)
+
+        # Specify dtype otherwise pyzfp gets upset.
+        return decompress(buffer, (self.shape_pad[0], self.blockshape[1], self.shape_pad[2]),
+                                  np.dtype('float32'), rate=self.rate)
+
+    @lru_cache(maxsize=1)
+    def read_and_decompress_zslice_set(self, blocks_per_dim, zslice_first_block_offset, zslice_id):
+        zslice_unit_in_block = (zslice_id % self.blockshape[2]) // 4
+        # Allocate memory for compressed data
+        buffer = bytearray(self.unit_bytes * (blocks_per_dim[0]) * (blocks_per_dim[1]))
+        for block_num in range((blocks_per_dim[0]) * (blocks_per_dim[1])):
+            self.file.seek(self.data_start_bytes + zslice_first_block_offset * self.block_bytes
+                           + zslice_unit_in_block * self.unit_bytes
+                           + block_num * self.chunk_bytes, 0)
+            buffer[block_num * self.unit_bytes:(block_num + 1) * self.unit_bytes] = self.file.read(self.unit_bytes)
+        # Specify dtype otherwise pyzfp gets upset.
+        decompressed = decompress(buffer, (self.shape_pad[0], self.shape_pad[1], 4),
+                                  np.dtype('float32'), rate=self.rate)
+        return decompressed
+
+    @lru_cache(maxsize=1)
+    def read_and_decompress_zslice_set_adv(self, blocks_per_dim, zslice_first_block_offset):
+        sub_block_size_bytes = ((4 * 4 * self.blockshape[1]) * self.rate) // 8
+        buffer = bytearray(self.block_bytes * blocks_per_dim[0] * blocks_per_dim[1])
+        for block_i in range(blocks_per_dim[0]):
+            for block_x in range(blocks_per_dim[1]):
+                block_num = block_i * (blocks_per_dim[1]) + block_x
+                self.file.seek(self.data_start_bytes + zslice_first_block_offset * self.block_bytes + block_num * (
+                            self.block_bytes * (blocks_per_dim[2])), 0)
+                temp_buf = self.file.read(self.block_bytes)
+                for sub_block_num in range(self.blockshape[0] // 4):
+                    buf_start = block_i * self.block_bytes * (
+                    blocks_per_dim[1]) + block_x * sub_block_size_bytes + sub_block_num * (
+                                            (self.shape_pad[1] * 4 * 4 * self.rate) // 8)
+                    buffer[buf_start:buf_start + sub_block_size_bytes] = \
+                        temp_buf[sub_block_num * sub_block_size_bytes:(sub_block_num + 1) * sub_block_size_bytes]
+        # Specify dtype otherwise pyzfp gets upset.
+        decompressed = decompress(buffer, (self.shape_pad[0], self.shape_pad[1], 4),
+                                  np.dtype('float32'), rate=self.rate)
+        return decompressed
+
+    @lru_cache(maxsize=2)
+    def read_and_decompress_cd_set(self, cd):
+        if cd < 0:
+            xl_first_chunk_offset = abs(cd) // 4 * self.chunk_bytes
+        else:
+            xl_first_chunk_offset = (cd // 4) * self.chunk_bytes * self.shape_pad[1] // 4
+
+        xl_chunk_increment = self.chunk_bytes * (self.shape_pad[1] + 4) // 4
+
+        # Allocate memory for compressed data
+        buffer = bytearray(self.chunk_bytes * self.shape_pad[0] // 4)
+
+        for chunk_num in range(self.shape_pad[0] // 4):
+            self.file.seek(self.data_start_bytes + xl_first_chunk_offset
+                           + chunk_num * xl_chunk_increment, 0)
+            buffer[chunk_num * self.chunk_bytes:(chunk_num + 1) * self.chunk_bytes] = self.file.read(self.chunk_bytes)
+
+        # Specify dtype otherwise pyzfp gets upset.
+        return decompress(buffer, (self.shape_pad[0], self.blockshape[1], self.shape_pad[2]),
+                                  np.dtype('float32'), rate=self.rate)
+
+    @lru_cache(maxsize=2)
+    def read_and_decompress_ad_set(self, ad):
+        if ad < self.shape_pad[1]:
+            xl_first_chunk_offset = ad // 4 * self.chunk_bytes
+        else:
+            xl_first_chunk_offset = (((ad - self.shape_pad[1]) // 4 + 2) * (self.shape_pad[1] // 4) - 1) * self.chunk_bytes
+
+        xl_chunk_increment = self.chunk_bytes * (self.shape_pad[1] - 4) // 4
+
+        # Allocate memory for compressed data
+        buffer = bytearray(self.chunk_bytes * self.shape_pad[0] // 4)
+
+        for chunk_num in range(self.shape_pad[0] // 4):
+            self.file.seek(self.data_start_bytes + xl_first_chunk_offset
+                           + chunk_num * xl_chunk_increment, 0)
+            buffer[chunk_num * self.chunk_bytes:(chunk_num + 1) * self.chunk_bytes] = self.file.read(self.chunk_bytes)
+
+        # Specify dtype otherwise pyzfp gets upset.
+        return decompress(buffer, (self.shape_pad[0], self.blockshape[1], self.shape_pad[2]),
+                                  np.dtype('float32'), rate=self.rate)
+
+    @lru_cache(maxsize=1)
+    def read_and_decompress_chunk_range(self, max_il, max_xl, max_z, min_il, min_xl, min_z):
+        z_units = (max_z + 4) // 4 - min_z // 4
+        xl_units = (max_xl + 4) // 4 - min_xl // 4
+        il_units = (max_il + 4) // 4 - min_il // 4
+        # Allocate memory for compressed data
+        buffer = bytearray(z_units * xl_units * il_units * self.unit_bytes)
+        read_length = self.unit_bytes * z_units
+        for i in range(il_units):
+            for x in range(xl_units):
+                # No need to loop over z... it's contiguous, so do it in one file read
+                self.file.seek(self.data_start_bytes + self.unit_bytes * (
+                        (i + (min_il // 4)) * (self.shape_pad[1] // 4) * (self.shape_pad[2] // 4) +
+                        (x + (min_xl // 4)) * (self.shape_pad[2] // 4) +
+                        (min_z // 4)), 0)
+                buf_start = (i * xl_units * z_units + x * z_units) * self.unit_bytes
+                buf_end = buf_start + read_length
+                buffer[buf_start:buf_end] = self.file.read(read_length)
+        # Specify dtype otherwise pyzfp gets upset.
+        decompressed = decompress(buffer, (il_units * 4, xl_units * 4, z_units * 4),
+                                  np.dtype('float32'), rate=self.rate)
+        return decompressed
+
+    @lru_cache(maxsize=1)
+    def read_unshuffle_and_decompress_chunk_range(self, max_il, max_xl, max_z, min_il, min_xl, min_z):
+        z_blocks = (max_z + self.blockshape[2]) // self.blockshape[2] - min_z // self.blockshape[2]
+        xl_blocks = (max_xl + self.blockshape[1]) // self.blockshape[1] - min_xl // self.blockshape[1]
+        il_blocks = (max_il + self.blockshape[0]) // self.blockshape[0] - min_il // self.blockshape[0]
+        decompressed = np.zeros((il_blocks * self.blockshape[0],
+                                 xl_blocks * self.blockshape[1],
+                                 z_blocks * self.blockshape[2]), dtype=np.float32)
+        for i in range(il_blocks):
+            for x in range(xl_blocks):
+                for z in range(z_blocks):
+                    self.file.seek(self.data_start_bytes + self.block_bytes * (
+                            (i + (min_il // self.blockshape[0])) * (self.shape_pad[1] // self.blockshape[1]) * (
+                                self.shape_pad[2] // self.blockshape[2]) +
+                            (x + (min_xl // self.blockshape[1])) * (self.shape_pad[2] // self.blockshape[2]) +
+                            (z + (min_z // self.blockshape[2]))), 0)
+                    buffer = self.file.read(self.block_bytes)
+                    decompressed_part = decompress(buffer,
+                                                   (self.blockshape[0], self.blockshape[1], self.blockshape[2]),
+                                                   np.dtype('float32'), rate=self.rate)
+                    decompressed[i * self.blockshape[0]:(i + 1) * self.blockshape[0],
+                    x * self.blockshape[1]:(x + 1) * self.blockshape[1],
+                    z * self.blockshape[2]:(z + 1) * self.blockshape[2]] = decompressed_part
+        return decompressed

--- a/seismic_zfp/read.py
+++ b/seismic_zfp/read.py
@@ -27,7 +27,7 @@ class SzReader:
     read_subvolume(min_il, max_il, min_xl, max_xl, min_z, max_z)
         Decompresses and returns an arbitrary sub-volume from SZ file as 3D numpy array
     """
-    def __init__(self, file, filetype_checking=True):
+    def __init__(self, file, filetype_checking=True, preload=False):
         """
         Parameters
         ----------
@@ -107,8 +107,8 @@ class SzReader:
         self.variant_headers = None
 
         # Split out responsibility for I/O and decompression
-        self.loader = SzLoader(self.file, self.data_start_bytes, self.shape_pad,
-                               self.blockshape, self.chunk_bytes, self.block_bytes, self.unit_bytes, self.rate)
+        self.loader = SzLoader(self.file, self.data_start_bytes, self.compressed_data_diskblocks, self.shape_pad,
+                               self.blockshape, self.chunk_bytes, self.block_bytes, self.unit_bytes, self.rate, preload)
 
     def __enter__(self):
         return self

--- a/seismic_zfp/read.py
+++ b/seismic_zfp/read.py
@@ -459,6 +459,52 @@ class SzReader:
         else:
             raise NotImplementedError("Diagonals can only be read from default layout SZ files")
 
+    def read_and_decompress_chunk_range(self, max_il, max_xl, max_z, min_il, min_xl, min_z):
+        z_units = (max_z + 4) // 4 - min_z // 4
+        xl_units = (max_xl + 4) // 4 - min_xl // 4
+        il_units = (max_il + 4) // 4 - min_il // 4
+        # Allocate memory for compressed data
+        buffer = bytearray(z_units * xl_units * il_units * self.unit_bytes)
+        read_length = self.unit_bytes * z_units
+        for i in range(il_units):
+            for x in range(xl_units):
+                # No need to loop over z... it's contiguous, so do it in one file read
+                self.file.seek(self.data_start_bytes + self.unit_bytes * (
+                        (i + (min_il // 4)) * (self.shape_pad[1] // 4) * (self.shape_pad[2] // 4) +
+                        (x + (min_xl // 4)) * (self.shape_pad[2] // 4) +
+                        (min_z // 4)), 0)
+                buf_start = (i * xl_units * z_units + x * z_units) * self.unit_bytes
+                buf_end = buf_start + read_length
+                buffer[buf_start:buf_end] = self.file.read(read_length)
+        # Specify dtype otherwise pyzfp gets upset.
+        decompressed = decompress(buffer, (il_units * 4, xl_units * 4, z_units * 4),
+                                  np.dtype('float32'), rate=self.rate)
+        return decompressed
+
+    def read_unshuffle_and_decompress_chunk_range(self, max_il, max_xl, max_z, min_il, min_xl, min_z):
+        z_blocks = (max_z + self.blockshape[2]) // self.blockshape[2] - min_z // self.blockshape[2]
+        xl_blocks = (max_xl + self.blockshape[1]) // self.blockshape[1] - min_xl // self.blockshape[1]
+        il_blocks = (max_il + self.blockshape[0]) // self.blockshape[0] - min_il // self.blockshape[0]
+        decompressed = np.zeros((il_blocks * self.blockshape[0],
+                                 xl_blocks * self.blockshape[1],
+                                 z_blocks * self.blockshape[2]), dtype=np.float32)
+        for i in range(il_blocks):
+            for x in range(xl_blocks):
+                for z in range(z_blocks):
+                    self.file.seek(self.data_start_bytes + self.block_bytes * (
+                            (i + (min_il // self.blockshape[0])) * (self.shape_pad[1] // self.blockshape[1]) * (
+                                self.shape_pad[2] // self.blockshape[2]) +
+                            (x + (min_xl // self.blockshape[1])) * (self.shape_pad[2] // self.blockshape[2]) +
+                            (z + (min_z // self.blockshape[2]))), 0)
+                    buffer = self.file.read(self.block_bytes)
+                    decompressed_part = decompress(buffer,
+                                                   (self.blockshape[0], self.blockshape[1], self.blockshape[2]),
+                                                   np.dtype('float32'), rate=self.rate)
+                    decompressed[i * self.blockshape[0]:(i + 1) * self.blockshape[0],
+                    x * self.blockshape[1]:(x + 1) * self.blockshape[1],
+                    z * self.blockshape[2]:(z + 1) * self.blockshape[2]] = decompressed_part
+        return decompressed
+
     def read_subvolume(self, min_il, max_il, min_xl, max_xl, min_z, max_z):
         """Reads a sub-volume from SZ file
 
@@ -486,28 +532,7 @@ class SzReader:
             The sprcified subvolume, decompressed
         """
         if self.blockshape[0] == 4 and self.blockshape[1] == 4:
-            z_units = (max_z+4) // 4 - min_z // 4
-            xl_units = (max_xl+4) // 4 - min_xl // 4
-            il_units = (max_il+4) // 4 - min_il // 4
-
-            # Allocate memory for compressed data
-            buffer = bytearray(z_units * xl_units * il_units * self.unit_bytes)
-            read_length = self.unit_bytes*z_units
-
-            for i in range(il_units):
-                for x in range(xl_units):
-                    # No need to loop over z... it's contiguous, so do it in one file read
-                    self.file.seek(self.data_start_bytes + self.unit_bytes * (
-                          (i + (min_il // 4))*(self.shape_pad[1] // 4) * (self.shape_pad[2] // 4) +
-                          (x + (min_xl // 4))*(self.shape_pad[2] // 4) +
-                          (min_z // 4)), 0)
-                    buf_start = (i*xl_units*z_units + x*z_units) * self.unit_bytes
-                    buf_end = buf_start + read_length
-                    buffer[buf_start:buf_end] = self.file.read(read_length)
-
-            # Specify dtype otherwise pyzfp gets upset.
-            decompressed = decompress(buffer, (il_units*4, xl_units*4, z_units*4),
-                                      np.dtype('float32'), rate=self.rate)
+            decompressed = self.read_and_decompress_chunk_range(max_il, max_xl, max_z, min_il, min_xl, min_z)
 
             return decompressed[min_il%4:(min_il%4)+max_il-min_il,
                                 min_xl%4:(min_xl%4)+max_xl-min_xl,
@@ -517,32 +542,11 @@ class SzReader:
             # Really should encourage users to stick with either:
             #  - blockshape[2] == 4
             #  - blockshape[0] == blockshape[1] == 4
-            z_blocks = (max_z+self.blockshape[2]) // self.blockshape[2] - min_z // self.blockshape[2]
-            xl_blocks = (max_xl+self.blockshape[1]) // self.blockshape[1] - min_xl // self.blockshape[1]
-            il_blocks = (max_il+self.blockshape[0]) // self.blockshape[0] - min_il // self.blockshape[0]
+            decompressed = self.read_unshuffle_and_decompress_chunk_range(max_il, max_xl, max_z, min_il, min_xl, min_z)
 
-            data_padded = np.zeros((il_blocks*self.blockshape[0],
-                                    xl_blocks*self.blockshape[1],
-                                    z_blocks*self.blockshape[2]), dtype=np.float32)
-
-            for i in range(il_blocks):
-                for x in range(xl_blocks):
-                    for z in range(z_blocks):
-                        self.file.seek(self.data_start_bytes + self.block_bytes * (
-                                (i + (min_il // self.blockshape[0])) * (self.shape_pad[1] // self.blockshape[1]) * (self.shape_pad[2] // self.blockshape[2]) +
-                                (x + (min_xl // self.blockshape[1])) * (self.shape_pad[2] // self.blockshape[2]) +
-                                (z + (min_z // self.blockshape[2]))), 0)
-                        buffer = self.file.read(self.block_bytes)
-                        decompressed = decompress(buffer,
-                                                  (self.blockshape[0], self.blockshape[1], self.blockshape[2]),
-                                                  np.dtype('float32'), rate=self.rate)
-                        data_padded[i*self.blockshape[0]:(i+1)*self.blockshape[0],
-                                    x*self.blockshape[1]:(x+1)*self.blockshape[1],
-                                    z*self.blockshape[2]:(z+1)*self.blockshape[2]] = decompressed
-
-            return data_padded[min_il%self.blockshape[0]:(min_il%self.blockshape[0])+max_il-min_il,
-                               min_xl%self.blockshape[1]:(min_xl%self.blockshape[1])+max_xl-min_xl,
-                               min_z%self.blockshape[2]:(min_z%self.blockshape[2])+max_z-min_z]
+            return decompressed[min_il%self.blockshape[0]:(min_il%self.blockshape[0])+max_il-min_il,
+                                min_xl%self.blockshape[1]:(min_xl%self.blockshape[1])+max_xl-min_xl,
+                                min_z%self.blockshape[2]:(min_z%self.blockshape[2])+max_z-min_z]
 
     def read_volume(self):
         return self.read_subvolume(0, self.n_ilines,

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -13,11 +13,13 @@ SEGY_FILE = 'test_data/small.sgy'
 
 
 def compare_inline(sz_filename, tolerance):
-    for line_number in range(5):
-        slice_sz = SzReader(sz_filename).read_inline(line_number)
-        with segyio.open(SEGY_FILE) as segyfile:
-            slice_segy = segyfile.iline[segyfile.ilines[line_number]]
-        assert np.allclose(slice_sz, slice_segy, rtol=tolerance)
+    for preload in [True, False]:
+        reader = SzReader(sz_filename, preload=preload)
+        for line_number in range(5):
+            slice_sz = reader.read_inline(line_number)
+            with segyio.open(SEGY_FILE) as segyfile:
+                slice_segy = segyfile.iline[segyfile.ilines[line_number]]
+            assert np.allclose(slice_sz, slice_segy, rtol=tolerance)
 
 
 def test_read_inline():
@@ -30,11 +32,13 @@ def test_read_inline():
 
 
 def compare_crossline(sz_filename, tolerance):
-    for line_number in range(5):
-        slice_sz = SzReader(sz_filename).read_crossline(line_number)
-        with segyio.open(SEGY_FILE) as segyfile:
-            slice_segy = segyfile.xline[segyfile.xlines[line_number]]
-        assert np.allclose(slice_sz, slice_segy, rtol=tolerance)
+    for preload in [True, False]:
+        reader = SzReader(sz_filename, preload=preload)
+        for line_number in range(5):
+            slice_sz = reader.read_crossline(line_number)
+            with segyio.open(SEGY_FILE) as segyfile:
+                slice_segy = segyfile.xline[segyfile.xlines[line_number]]
+            assert np.allclose(slice_sz, slice_segy, rtol=tolerance)
 
 
 def test_read_crossline():
@@ -47,11 +51,13 @@ def test_read_crossline():
 
 
 def compare_zslice(sz_filename, tolerance):
-    for line_number in range(50):
-        slice_sz = SzReader(sz_filename).read_zslice(line_number)
-        with segyio.open(SEGY_FILE) as segyfile:
-            slice_segy = segyfile.depth_slice[line_number]
-        assert np.allclose(slice_sz, slice_segy, rtol=tolerance)
+    for preload in [True, False]:
+        reader = SzReader(sz_filename, preload=preload)
+        for line_number in range(50):
+            slice_sz = reader.read_zslice(line_number)
+            with segyio.open(SEGY_FILE) as segyfile:
+                slice_segy = segyfile.depth_slice[line_number]
+            assert np.allclose(slice_sz, slice_segy, rtol=tolerance)
 
 
 def test_read_zslice():
@@ -64,18 +70,20 @@ def test_read_zslice():
 
 
 def compare_correlated_diagonal(sz_filename, tolerance):
-    for line_number in range(-4, 4):
-        slice_sz = SzReader(sz_filename).read_correlated_diagonal(line_number)
-        with segyio.open(SEGY_FILE) as segyfile:
-            diagonal_length = get_correlated_diagonal_length(line_number, len(segyfile.ilines), len(segyfile.xlines))
-            slice_segy = np.zeros((diagonal_length, len(segyfile.samples)))
-            if line_number >= 0:
-                for d in range(diagonal_length):
-                    slice_segy[d, :] = segyfile.trace[(d+line_number)*len(segyfile.xlines) + d]
-            else:
-                for d in range(diagonal_length):
-                    slice_segy[d, :] = segyfile.trace[d*len(segyfile.xlines) + d - line_number]
-        assert np.allclose(slice_sz, slice_segy, rtol=tolerance)
+    for preload in [True, False]:
+        reader = SzReader(sz_filename, preload=preload)
+        for line_number in range(-4, 4):
+            slice_sz = reader.read_correlated_diagonal(line_number)
+            with segyio.open(SEGY_FILE) as segyfile:
+                diagonal_length = get_correlated_diagonal_length(line_number, len(segyfile.ilines), len(segyfile.xlines))
+                slice_segy = np.zeros((diagonal_length, len(segyfile.samples)))
+                if line_number >= 0:
+                    for d in range(diagonal_length):
+                        slice_segy[d, :] = segyfile.trace[(d+line_number)*len(segyfile.xlines) + d]
+                else:
+                    for d in range(diagonal_length):
+                        slice_segy[d, :] = segyfile.trace[d*len(segyfile.xlines) + d - line_number]
+            assert np.allclose(slice_sz, slice_segy, rtol=tolerance)
 
 
 def test_read_correlated_diagonal():
@@ -88,20 +96,22 @@ def test_read_correlated_diagonal():
 
 
 def compare_anticorrelated_diagonal(sz_filename, tolerance):
-    for line_number in range(6):
-        print("\n\n\n\n", line_number)
-        slice_sz = SzReader(sz_filename).read_anticorrelated_diagonal(line_number)
-        with segyio.open(SEGY_FILE) as segyfile:
-            diagonal_length = get_anticorrelated_diagonal_length(line_number, len(segyfile.ilines), len(segyfile.xlines))
-            slice_segy = np.zeros((diagonal_length, len(segyfile.samples)))
-            if line_number < len(segyfile.xlines):
-                for d in range(diagonal_length):
-                    slice_segy[d, :] = segyfile.trace[line_number + d * (len(segyfile.xlines) - 1)]
-            else:
-                for d in range(diagonal_length):
-                    slice_segy[d, :] = segyfile.trace[(line_number - len(segyfile.xlines) + 1 + d) * len(segyfile.xlines)
-                                                      + (len(segyfile.xlines) - d - 1)]
-        assert np.allclose(slice_sz, slice_segy, rtol=tolerance)
+    for preload in [True, False]:
+        reader = SzReader(sz_filename, preload=preload)
+        for line_number in range(6):
+            print("\n\n\n\n", line_number)
+            slice_sz = reader.read_anticorrelated_diagonal(line_number)
+            with segyio.open(SEGY_FILE) as segyfile:
+                diagonal_length = get_anticorrelated_diagonal_length(line_number, len(segyfile.ilines), len(segyfile.xlines))
+                slice_segy = np.zeros((diagonal_length, len(segyfile.samples)))
+                if line_number < len(segyfile.xlines):
+                    for d in range(diagonal_length):
+                        slice_segy[d, :] = segyfile.trace[line_number + d * (len(segyfile.xlines) - 1)]
+                else:
+                    for d in range(diagonal_length):
+                        slice_segy[d, :] = segyfile.trace[(line_number - len(segyfile.xlines) + 1 + d) * len(segyfile.xlines)
+                                                          + (len(segyfile.xlines) - d - 1)]
+            assert np.allclose(slice_sz, slice_segy, rtol=tolerance)
 
 
 def test_read_anticorrelated_diagonal():
@@ -114,14 +124,15 @@ def test_read_anticorrelated_diagonal():
 
 
 def compare_subvolume(sz_filename, tolerance):
-    min_il, max_il = 2,  3
-    min_xl, max_xl = 1,  2
-    min_z,  max_z = 10, 20
-    vol_sz = SzReader(sz_filename).read_subvolume(min_il=min_il, max_il=max_il,
-                                                  min_xl=min_xl, max_xl=max_xl,
-                                                  min_z=min_z, max_z=max_z)
-    vol_segy = segyio.tools.cube(SEGY_FILE)[min_il:max_il, min_xl:max_xl, min_z:max_z]
-    assert np.allclose(vol_sz, vol_segy, rtol=tolerance)
+    for preload in [True, False]:
+        min_il, max_il = 2,  3
+        min_xl, max_xl = 1,  2
+        min_z,  max_z = 10, 20
+        vol_sz = SzReader(sz_filename, preload=preload).read_subvolume(min_il=min_il, max_il=max_il,
+                                                      min_xl=min_xl, max_xl=max_xl,
+                                                      min_z=min_z, max_z=max_z)
+        vol_segy = segyio.tools.cube(SEGY_FILE)[min_il:max_il, min_xl:max_xl, min_z:max_z]
+        assert np.allclose(vol_sz, vol_segy, rtol=tolerance)
 
 
 def test_read_subvolume():


### PR DESCRIPTION
Enable users to specify the boolean "preload" when instantiating an SzReader, which will read and maintain in memory the compressed representation of the entire cube. Good for when reading a file multiple times.