### PR TITLE
Individual header reads

### DIFF
--- a/seismic_zfp/accessors.py
+++ b/seismic_zfp/accessors.py
@@ -67,7 +67,6 @@ class ZsliceAccessor(Accessor, Mapping):
 class HeaderAccessor(Accessor, Mapping):
     def __init__(self, file):
         super(Accessor, self).__init__(file)
-        self.read_variant_headers()
         self.len_object = self.tracecount
         self.keys_object = list(range(self.tracecount))
         self.values_function = self.gen_trace_header

--- a/seismic_zfp/read.py
+++ b/seismic_zfp/read.py
@@ -540,6 +540,7 @@ class SgzReader(object):
         if not 0 <= index < self.n_ilines * self.n_xlines:
             raise IndexError(self.range_error.format(index, 0, self.tracecount))
 
+        self.read_variant_headers()
         header = self.segy_traceheader_template.copy()
         for k, v in header.items():
             if isinstance(v, FileOffset):

--- a/seismic_zfp/read.py
+++ b/seismic_zfp/read.py
@@ -553,7 +553,7 @@ class SgzReader(object):
                     header[k] = self.variant_headers[k][index]
                 else:
                     self.file.seek(v + 4*index)  # A 32-bit int is 4 bytes
-                    header[k] = np.frombuffer(self.file.read(4), dtype=np.int32)
+                    header[k] = np.frombuffer(self.file.read(4), dtype=np.int32)[0]
         return header
 
     def get_file_binary_header(self):

--- a/seismic_zfp/read.py
+++ b/seismic_zfp/read.py
@@ -73,13 +73,13 @@ class SgzReader(object):
              : file handle in 'rb' mode
              Reuse an open file handle
 
-        filetype_checking : bool
+        filetype_checking : bool, optional
             Decline to attempt reading files which look like SEG-Y
 
-        preload : bool
+        preload : bool, optional
             Read whole volume (compressed) into memory at instantiation
 
-        chunk_cache_size : int
+        chunk_cache_size : int, optional
             Number of chunks to cache when reading traces, increase for long diagonals
         """
 
@@ -442,7 +442,7 @@ class SgzReader(object):
         max_z : int
             The ordinal number of the maximum zslice to read (C-indexing)
 
-        access_padding : bool
+        access_padding : bool, optional
             Functions which manage voxels used for padding themselves may relax bounds-checking to padded dimensions
 
         Returns
@@ -524,13 +524,17 @@ class SgzReader(object):
                                    ref_xl, ref_xl + self.blockshape[1],
                                    0, self.n_samples, access_padding=True)
 
-    def gen_trace_header(self, index):
+    def gen_trace_header(self, index, load_all_headers=False):
         """Generates one trace header from SGZ file
 
         Parameters
         ----------
         index : int
             The ordinal number of the trace header in the file
+
+        load_all_headers : bool, optional
+            Load full header-arrays from disk.
+            More efficient if accessing headers for whole file.
 
         Returns
         -------
@@ -540,11 +544,16 @@ class SgzReader(object):
         if not 0 <= index < self.n_ilines * self.n_xlines:
             raise IndexError(self.range_error.format(index, 0, self.tracecount))
 
-        self.read_variant_headers()
         header = self.segy_traceheader_template.copy()
+
         for k, v in header.items():
             if isinstance(v, FileOffset):
-                header[k] = self.variant_headers[k][index]
+                if load_all_headers:
+                    self.read_variant_headers()
+                    header[k] = self.variant_headers[k][index]
+                else:
+                    self.file.seek(v + 4*index)  # A 32-bit int is 4 bytes
+                    header[k] = np.frombuffer(self.file.read(4), dtype=np.int32)
         return header
 
     def get_file_binary_header(self):

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -34,6 +34,15 @@ def test_read_trace_header():
             assert sgz_header == sgy_header
 
 
+def test_read_trace_header_preload():
+    reader = SgzReader(SGZ_FILE_1)
+    with segyio.open(SGY_FILE) as sgyfile:
+        for trace_number in range(25):
+            sgz_header = reader.gen_trace_header(trace_number, load_all_headers=True)
+            sgy_header = sgyfile.header[trace_number]
+            assert sgz_header == sgy_header
+
+
 def compare_inline(sgz_filename, sgy_filename, lines, tolerance):
     with segyio.open(sgy_filename) as segyfile:
         for preload in [True, False]:

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -25,6 +25,15 @@ SGZ_SGY_FILE_PAIRS = [('test_data/padding/padding_{}x{}.sgz'.format(n, m),
                       for n, m in itertools.product([5, 6, 7, 8], [5, 6, 7, 8])]
 
 
+def test_read_trace_header():
+    reader = SgzReader(SGZ_FILE_1)
+    with segyio.open(SGY_FILE) as sgyfile:
+        for trace_number in range(25):
+            sgz_header = reader.gen_trace_header(trace_number)
+            sgy_header = sgyfile.header[trace_number]
+            assert sgz_header == sgy_header
+
+
 def compare_inline(sgz_filename, sgy_filename, lines, tolerance):
     with segyio.open(sgy_filename) as segyfile:
         for preload in [True, False]:


### PR DESCRIPTION
No need to read full header arrays for big files when accessing single trace headers. Leave this available as an optional parameter.