### PR TITLE
Makes pyvds and pyzgy dependencies optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 venv/*
 .idea
+.vscode
 .eggs/*
 seismic_zfp/__pycache__/*
 seismic_zfp/*.pyc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pillow
 matplotlib
+pytest

--- a/seismic_zfp/conversion.py
+++ b/seismic_zfp/conversion.py
@@ -13,13 +13,6 @@ from .read import SgzReader
 from .sgzconstants import DISK_BLOCK_BYTES, SEGY_FILE_HEADER_BYTES
 from .seismicfile import SeismicFile, Filetype
 
-try:
-    import zgy2sgz
-except ImportError:
-    _has_zgy2sgz = False
-else:
-    _has_zgy2sgz = True
-
 
 class SeismicFileConverter(object):
     """

--- a/seismic_zfp/seismicfile.py
+++ b/seismic_zfp/seismicfile.py
@@ -1,9 +1,17 @@
 import os
 from enum import Enum
 
-import pyvds
-import pyzgy
 import segyio
+
+try:
+    import pyzgy
+except ImportError:
+    pyzgy = None
+
+try:
+    import pyvds
+except ImportError:
+    pyvds = None
 
 
 class Filetype(Enum):
@@ -27,12 +35,18 @@ class SeismicFile:
                 file_type = Filetype.VDS
             else:
                 raise ValueError("Unknown file extension: '{}'".format(ext))
+        elif not isinstance(file_type, Filetype):
+                raise ValueError("Not a valid file_type. Must be of type Filetype")
 
         if file_type == Filetype.SEGY:
             handle = segyio.open(filename, mode='r', strict=False)
         elif file_type == Filetype.ZGY:
+            if pyzgy is None:
+                raise ImportError("File type requires pyzgy. Install optional dependency seismic-zfp[zgy] with pip.")
             handle = pyzgy.open(filename)
         elif file_type == Filetype.VDS:
+            if pyvds is None:
+                raise ImportError("File type requires pyvds. Install optional dependency seismic-zfp[vds] with pip.")
             handle = pyvds.open(filename)
 
         handle.filetype = file_type

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,9 +6,7 @@ import os
 try:
     import pyzgy
 except ImportError:
-    _has_pyzgy = False
-else:
-    _has_pyzgy = True
+    pyzgy = None
 
 def test_sgy2sgz():
     runner = CliRunner()
@@ -89,14 +87,14 @@ def test_sgy2sgz_convert_all_params():
     assert result.exit_code == 0
 
 
-@pytest.mark.skipif(not _has_pyzgy, reason="Requires pyzgy")
+@pytest.mark.skipif(pyzgy is None, reason="Requires pyzgy")
 def test_zgy2sgz():
     runner = CliRunner()
     result = runner.invoke(cli, ["zgy2sgz", "--help"])
     assert result.exit_code == 0
 
 
-@pytest.mark.skipif(not _has_pyzgy, reason="Requires pyzgy")
+@pytest.mark.skipif(pyzgy is None, reason="Requires pyzgy")
 def test_zgy2sgz_convert_default():
     input_file = os.path.join("test_data", "zgy", "small-8bit.zgy")
     input_file_absolute = os.path.abspath(input_file)
@@ -109,7 +107,7 @@ def test_zgy2sgz_convert_default():
     assert result.exit_code == 0
 
 
-@pytest.mark.skipif(not _has_pyzgy, reason="Requires pyzgy")
+@pytest.mark.skipif(pyzgy is None, reason="Requires pyzgy")
 def test_zgy2sgz_convert_bits_per_voxel():
     input_file = os.path.join("test_data", "zgy", "small-16bit.zgy")
     input_file_absolute = os.path.abspath(input_file)
@@ -124,7 +122,7 @@ def test_zgy2sgz_convert_bits_per_voxel():
     assert result.exit_code == 0
 
 
-@pytest.mark.skipif(not _has_pyzgy, reason="Requires pyzgy")
+@pytest.mark.skipif(pyzgy is None, reason="Requires pyzgy")
 def test_zgy2sgz_convert_all_params():
     input_file = os.path.join("test_data", "zgy", "small-32bit.zgy")
     input_file_absolute = os.path.abspath(input_file)

--- a/tests/test_seismicfile.py
+++ b/tests/test_seismicfile.py
@@ -1,0 +1,53 @@
+import pytest
+from importlib import reload
+from unittest import mock
+from seismic_zfp import seismicfile
+
+try:
+    import pyzgy
+except ImportError:
+    pyzgy = None
+
+try:
+    import pyvds
+except ImportError:
+    pyvds = None
+
+
+ZGY_FILE = 'test_data/zgy/small-8bit.zgy'
+VDS_FILE = 'test_data/vds/small.vds'
+
+
+def test_raises_import_error_if_missing_pyzgy():
+    # Modifies imports. Have to reload before and after
+    # to not affect other tests
+    with mock.patch.dict('sys.modules', {'pyzgy': None}):
+        reload(seismicfile) 
+        with pytest.raises(ImportError):
+            seismicfile.SeismicFile.open(ZGY_FILE, seismicfile.Filetype.ZGY)
+    reload(seismicfile) 
+
+
+def test_raises_import_error_if_missing_pyvds():
+    with mock.patch.dict('sys.modules', {'pyvds': None}):
+        reload(seismicfile) 
+        with pytest.raises(ImportError):
+            seismicfile.SeismicFile.open(VDS_FILE, seismicfile.Filetype.VDS)
+    reload(seismicfile) 
+
+
+def test_raises_value_error_if_file_type_unknown():
+        with pytest.raises(ValueError):
+            seismicfile.SeismicFile.open("", "unknown")
+
+
+@pytest.mark.skipif(pyvds is None, reason="Requires pyvds")
+def test_can_open_vds_file():
+    with seismicfile.SeismicFile.open(VDS_FILE) as seismic:
+        assert seismic.filetype is seismicfile.Filetype.VDS
+
+
+@pytest.mark.skipif(pyzgy is None, reason="Requires pyzgy")
+def test_can_open_zgy_file():
+    with seismicfile.SeismicFile.open(ZGY_FILE) as seismic:
+        assert seismic.filetype is seismicfile.Filetype.ZGY


### PR DESCRIPTION
* Try/Except of imports in seismicfile
* Adds pytest to requirements-dev.txt
* Remove old zgy2sgz optional import
* Raise ValueError in cases where file_type is not a Filetype enum
* Adds tests for seismicfile