### PR TITLE
Hard coded source coordinate scalar to -100 when converting from zgy …

### DIFF
--- a/seismic_zfp/headers.py
+++ b/seismic_zfp/headers.py
@@ -65,6 +65,7 @@ class HeaderwordInfo:
                 # Set up hw table with entries possible to scrape out of ZGY
                 self.table[115] = (int(seismicfile.n_samples), 0)
                 self.table[117] = (int(1000*seismicfile.zinc), 0)
+                self.table[71] = (-100, 0)
                 for hw_code in [181, 185, 189, 193]:
                     self.table[hw_code] = (0, hw_code)
 

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -164,7 +164,7 @@ def compress_and_compare_zgy(zgy_file, sgy_file, tmp_path, bits_per_voxel, rtol,
             for trace_number in range(25):
                 sgz_header = sgzfile.header[trace_number]
                 zgy_header = zgyfile.header[trace_number]
-                for header_pos in [115, 117, 181, 185, 189, 193]:
+                for header_pos in [71, 115, 117, 181, 185, 189, 193]:
                     assert sgz_header[header_pos] == zgy_header[header_pos]
 
     assert np.allclose(sgz_data, segyio.tools.cube(sgy_file), rtol=rtol)


### PR DESCRIPTION
UTM coordinates in zgy files are always supposed to be divided by 100 (as done by pyzgy). This change also sets the SourceGroupScalar headerword to -100 when running the seismic-zfp conversion to sgz. 