### PR TITLE
Fix division by zero bug for cubes with only one line

### DIFF
--- a/seismic_zfp/utils.py
+++ b/seismic_zfp/utils.py
@@ -53,7 +53,11 @@ class InferredGeometry3d(Geometry3d):
 
     @staticmethod
     def get_range(ids):
-        return min(ids), max(ids), (max(ids) - min(ids)) // (len(ids) - 1)
+        if len(ids)>1:
+            step = (max(ids) - min(ids)) // (len(ids) - 1)
+        else:
+            step = 0 # For 3D cubes with only one inline or crossline
+        return min(ids), max(ids), step
 
     def __repr__(self):
         return f'IL:[{self.min_il},{self.max_il},{self.il_step}] -- XL:[{self.min_xl},{self.max_xl},{self.xl_step}]'


### PR DESCRIPTION
Fixes this bug:

`from seismic_zfp.conversion import SegyConverter
import segyio
path_to_segy = 'MC3D-GH2001R02BP-3D-PSTM-FINAL-FAR-VOLUME-STACK.MIG_FIN.10249887981_0000139-0000679.SEGY'
segy = segyio.open(path_to_segy, ignore_geometry=True, strict=False)
il = segy.attributes(segyio.TraceField.INLINE_3D)
print('inlines:',set(il))
with SegyConverter(path_to_segy) as converter:
    converter.run(path_to_segy + '.zfp', bits_per_voxel=4)
inlines: {0}
SEG-Y file is unstructured and no geometry provided. Determining this may take some time...
Converting: In=MC3D-GH2001R02BP-3D-PSTM-FINAL-FAR-VOLUME-STACK.MIG_FIN.10249887981_0000139-0000679.SEGY, Out=MC3D-GH2001R02BP-3D-PSTM-FINAL-FAR-VOLUME-STACK.MIG_FIN.10249887981_0000139-0000679.SEGY.zfp
Traceback (most recent call last):
  File "/nr/bamjo/user/andersuw/.pycharm_helpers/pydev/pydevconsole.py", line 364, in runcode
    coro = func()
  File "<input>", line 16, in <module>
  File "/nr/project/common/Statoil-DELI/usr/andersuw/deli_standalone_2/venv_deli_2/lib/python3.10/site-packages/seismic_zfp/conversion.py", line 226, in run
    self.infer_geometry(seismic)
  File "/nr/project/common/Statoil-DELI/usr/andersuw/deli_standalone_2/venv_deli_2/lib/python3.10/site-packages/seismic_zfp/conversion.py", line 164, in infer_geometry
    self.geom = InferredGeometry3d(traces_ref)
  File "/nr/project/common/Statoil-DELI/usr/andersuw/deli_standalone_2/venv_deli_2/lib/python3.10/site-packages/seismic_zfp/utils.py", line 49, in __init__
    self.min_il, self.max_il, self.il_step = self.get_range(il_ids)
  File "/nr/project/common/Statoil-DELI/usr/andersuw/deli_standalone_2/venv_deli_2/lib/python3.10/site-packages/seismic_zfp/utils.py", line 56, in get_range
    return min(ids), max(ids), (max(ids) - min(ids)) // (len(ids) - 1)
ZeroDivisionError: integer division or modulo by zero
`