### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,7 @@
 name: Codecov
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,6 @@
 name: Publish to PyPI
+permissions:
+  contents: read
 
 on:
   release:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/seismic-zfp/security/code-scanning/3](https://github.com/equinor/seismic-zfp/security/code-scanning/3)

To fix the problem, we should add an explicit `permissions` block to the workflow. The best place is at the root of the workflow file (above `jobs:`), which applies the permissions to all jobs unless overridden. Since the steps in this workflow only check out code and upload coverage stats, write permissions are not required. The minimal required permission is likely `contents: read` (required by actions/checkout and coverage upload), which matches best practices for security.  
**Edits to make:**  
- In `.github/workflows/codecov.yml`, between the `on:` and `jobs:` lines, insert:  
  ```yaml
  permissions:
    contents: read
  ```
No imports or methods required; this is a declarative change in a YAML workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
