### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,7 @@
 name: Codecov
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/seismic-zfp/security/code-scanning/3](https://github.com/equinor/seismic-zfp/security/code-scanning/3)

To fix the problem, we should add an explicit `permissions` block to the workflow. The best place is at the root of the workflow file (above `jobs:`), which applies the permissions to all jobs unless overridden. Since the steps in this workflow only check out code and upload coverage stats, write permissions are not required. The minimal required permission is likely `contents: read` (required by actions/checkout and coverage upload), which matches best practices for security.  
**Edits to make:**  
- In `.github/workflows/codecov.yml`, between the `on:` and `jobs:` lines, insert:  
  ```yaml
  permissions:
    contents: read
  ```
No imports or methods required; this is a declarative change in a YAML workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
