### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,6 @@
 name: Publish to PyPI
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/seismic-zfp/security/code-scanning/2](https://github.com/equinor/seismic-zfp/security/code-scanning/2)

To address the problem, we should add a `permissions` block to the workflow. Since this workflow only checks out code, runs tests, builds the package, and publishes to PyPI using a secret, the only likely required permissions are for reading repository contents (i.e., `contents: read`). The workflow does not appear to create issues, comments, or other artifacts that require additional write privileges. The fix involves inserting `permissions: contents: read` at the root level of the workflow file (.github/workflows/publish-to-pypi.yml), ideally directly below the `name:` declaration and before the `on:` block so that it covers all jobs unless a job-specific block is present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
