### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
 


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/seismic-zfp/security/code-scanning/1](https://github.com/equinor/seismic-zfp/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/run_tests.yml` at the workflow root (best single change), so it applies to all jobs unless overridden. For this workflow, set:

- `contents: read`

This is the least-privilege baseline needed for `actions/checkout` and read-only CI test execution. No imports, methods, or additional definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
